### PR TITLE
Add allowed operations to be able to sync with recommended DNS conf

### DIFF
--- a/dynette.cron.py
+++ b/dynette.cron.py
@@ -11,11 +11,14 @@ rname     = 'hostmaster@yunohost.org' # Responsible person (https://tools.ietf.o
 
 allowed_operations = {
             '.'                  : ['A', 'AAAA', 'TXT', 'MX'],
-            'pubsub.'            : ['A', 'AAAA'],
-            'muc.'               : ['A', 'AAAA'],
-            'vjud.'              : ['A', 'AAAA'],
+            '*'                  : ['A', 'AAAA'],
+            'pubsub.'            : ['A', 'AAAA', 'CNAME'],
+            'muc.'               : ['A', 'AAAA', 'CNAME'],
+            'vjud.'              : ['A', 'AAAA', 'CNAME'],
             '_xmpp-client._tcp.' : ['SRV'],
-            '_xmpp-server._tcp.' : ['SRV']
+            '_xmpp-server._tcp.' : ['SRV'],
+            'mail._domainkey'    : ['TXT'],
+            '_dmarc'             : ['TXT']
 }
 
 


### PR DESCRIPTION
Related to https://github.com/YunoHost/yunohost/pull/299

We need new allowed operations in the dynette / dyndns update, especially for DKIM