### PR TITLE
Support hmac-sha512 for TSIG and allow migrating an existing md5 sig to a sha512 sig

### DIFF
--- a/dynette.cron.py
+++ b/dynette.cron.py
@@ -95,7 +95,7 @@ for url in subs_urls:
         for entry in result:
             lines.extend([
                 'key '+ entry['subdomain'] +'. {',
-                '       algorithm hmac-md5;',
+                '       algorithm ' + entry['key_algo'] + ';',
                 '       secret "'+ entry['public_key'] +'";',
                 '};',
             ])

--- a/dynette.cron.py
+++ b/dynette.cron.py
@@ -119,3 +119,9 @@ else:
     os.system('/usr/sbin/rndc reload')
     print("An error occured ! Please check daemon.log and your conf.bad")
     exit(1)
+
+# mein got this is so awful
+if os.path.exists('/tmp/dynette_flush_bind_cache'):
+    os.system('/usr/sbin/rndc flush')
+    os.system('/usr/sbin/rndc reload')
+    os.system('rm /tmp/dynette_flush_bind_cache')

--- a/dynette.rb
+++ b/dynette.rb
@@ -205,7 +205,7 @@ post '/key/:public_key' do
 end
 
 # Migrate a key from hmac-md5 to hmac-sha512 because it's 2017
-put '/migrate_key_to_sha512/:public_key' do
+put '/migrate_key_to_sha512/' do
     # TODO check parameters
     params[:public_key_md5] = Base64.decode64(params[:public_key_md5].encode('ascii-8bit'))
     params[:public_key_sha512] = Base64.decode64(params[:public_key_sha512].encode('ascii-8bit'))

--- a/dynette.rb
+++ b/dynette.rb
@@ -26,7 +26,8 @@ class Entry
     include BCrypt
 
     property :id, Serial
-    property :public_key, String
+    # we need at least 90 chars for hmac-sha512 keys
+    property :public_key, String, :length => 100
 
     # for historical reasons, dnssec algo was md5, so we assume that every
     # entry is using md5 while we provide automatic upgrade code inside

--- a/dynette.rb
+++ b/dynette.rb
@@ -30,7 +30,7 @@ class Entry
 
     # for historical reasons, dnssec algo was md5, so we assume that every
     # entry is using md5 while we provide automatic upgrade code inside
-    # yunohost to move to sha256 instead (and register new domains using sh256)
+    # yunohost to move to sha512 instead (and register new domains using sh512)
     # it would be good to depreciate md5 in the futur but that migh be complicated
     property :key_algo, String, :default => "hmac-md5"
 

--- a/dynette.rb
+++ b/dynette.rb
@@ -229,10 +229,11 @@ put '/migrate_key_to_sha512/' do
     end
 
     # need to regenerate bind9 stuff
-    `python ./dynette.cron.py`
+    # yes this is awful
+    `python /root/dynette/dynette.cron.py`
     # flush this idiotic bind cache because he doesn't know how to do that
     # himself
-    `rndc flush`
+    `/usr/sbin/rndc flush`
 
     halt 201, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
 end

--- a/dynette.rb
+++ b/dynette.rb
@@ -235,7 +235,7 @@ put '/migrate_key_to_sha512/' do
 
     # assume that the dynette.cron.py runs every minute like on prod and add a
     # bit of security margin. I hate that.
-    sleep(90)
+    sleep(180)
 
     halt 201, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
 end

--- a/dynette.rb
+++ b/dynette.rb
@@ -228,12 +228,13 @@ put '/migrate_key_to_sha512/' do
         halt 412, { :error => "A problem occured during key algo migration" }.to_json
     end
 
-    # need to regenerate bind9 stuff
-    # yes this is awful
-    `python /root/dynette/dynette.cron.py`
-    # flush this idiotic bind cache because he doesn't know how to do that
-    # himself
-    `/usr/sbin/rndc flush`
+    # I don't have any other way of communicating with this dynette.cron.py
+    # this is awful
+    File.open("/tmp/dynette_flush_bind_cache", "w").close
+
+    # assume that the dynette.cron.py runs every minute like on prod and add a
+    # bit of security margin. I hate that.
+    sleep(90)
 
     halt 201, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
 end

--- a/dynette.rb
+++ b/dynette.rb
@@ -234,7 +234,7 @@ put '/migrate_key_to_sha512/:public_key' do
     # himself
     `rndc flush`
 
-    halt 200, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
+    halt 201, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
 end
 
 # Update a sub-domain

--- a/dynette.rb
+++ b/dynette.rb
@@ -30,7 +30,7 @@ class Entry
 
     # for historical reasons, dnssec algo was md5, so we assume that every
     # entry is using md5 while we provide automatic upgrade code inside
-    # yunohost to move to sha512 instead (and register new domains using sh512)
+    # yunohost to move to sha512 instead (and register new domains using sha512)
     # it would be good to depreciate md5 in the futur but that migh be complicated
     property :key_algo, String, :default => "hmac-md5"
 

--- a/dynette.rb
+++ b/dynette.rb
@@ -115,7 +115,7 @@ end
         if params.has_key?("public_key")
             public_key = Base64.decode64(params[:public_key].encode('ascii-8bit'))
             # might be 88
-            unless public_key.length == 24 or public_key.length == 45
+            unless public_key.length == 24 or public_key.length == 32
                 halt 400, { :error => "Key is invalid: #{public_key.to_s.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})}" }.to_json
             end
         end

--- a/dynette.rb
+++ b/dynette.rb
@@ -115,7 +115,7 @@ end
     before path do
         if params.has_key?("public_key")
             public_key = Base64.decode64(params[:public_key].encode('ascii-8bit'))
-            unless public_key.length == 24 or public_key.length == 32
+            unless public_key.length == 24 or public_key.length == 89
                 halt 400, { :error => "Key is invalid: #{public_key.to_s.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})}" }.to_json
             end
         end

--- a/dynette.rb
+++ b/dynette.rb
@@ -115,7 +115,7 @@ end
         if params.has_key?("public_key")
             public_key = Base64.decode64(params[:public_key].encode('ascii-8bit'))
             # might be 88
-            unless public_key.length == 24 or public_key.length == 89
+            unless public_key.length == 24 or public_key.length == 45
                 halt 400, { :error => "Key is invalid: #{public_key.to_s.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})}" }.to_json
             end
         end

--- a/dynette.rb
+++ b/dynette.rb
@@ -115,7 +115,6 @@ end
     before path do
         if params.has_key?("public_key")
             public_key = Base64.decode64(params[:public_key].encode('ascii-8bit'))
-            # might be 88
             unless public_key.length == 24 or public_key.length == 32
                 halt 400, { :error => "Key is invalid: #{public_key.to_s.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})}" }.to_json
             end

--- a/dynette.rb
+++ b/dynette.rb
@@ -210,8 +210,6 @@ put '/migrate_key_to_sha512/' do
     params[:public_key_md5] = Base64.decode64(params[:public_key_md5].encode('ascii-8bit'))
     params[:public_key_sha512] = Base64.decode64(params[:public_key_sha512].encode('ascii-8bit'))
 
-    # TODO signing handling
-
     # TODO check entry exists
     entry = Entry.first(:public_key => params[:public_key_md5],
                         :key_algo => "hmac-md5")

--- a/dynette.rb
+++ b/dynette.rb
@@ -29,7 +29,7 @@ class Entry
     # we need at least 90 chars for hmac-sha512 keys
     property :public_key, String, :length => 100
 
-    # for historical reasons, dnssec algo was md5, so we assume that every
+    # for historical reasons, tsig algo was md5, so we assume that every
     # entry is using md5 while we provide automatic upgrade code inside
     # yunohost to move to sha512 instead (and register new domains using sha512)
     # it would be good to depreciate md5 in the futur but that migh be complicated

--- a/dynette.rb
+++ b/dynette.rb
@@ -27,6 +27,13 @@ class Entry
 
     property :id, Serial
     property :public_key, String
+
+    # for historical reasons, dnssec algo was md5, so we assume that every
+    # entry is using md5 while we provide automatic upgrade code inside
+    # yunohost to move to sha256 instead (and register new domains using sh256)
+    # it would be good to depreciate md5 in the futur but that migh be complicated
+    property :key_algo, String, :default => "hmac-md5"
+
     property :subdomain, String
     property :current_ip, String
     property :created_at, DateTime

--- a/dynette.rb
+++ b/dynette.rb
@@ -235,10 +235,6 @@ put '/migrate_key_to_sha512/' do
     # let's try flusing here, hope that could help ... (this design is so awful)
     `/usr/sbin/rndc flush`
 
-    # assume that the dynette.cron.py runs every minute like on prod and add a
-    # bit of security margin. I hate that.
-    sleep(180)
-
     halt 201, { :public_key => entry.public_key, :subdomain => entry.subdomain, :current_ip => entry.current_ip }.to_json
 end
 

--- a/dynette.rb
+++ b/dynette.rb
@@ -232,6 +232,8 @@ put '/migrate_key_to_sha512/' do
     # I don't have any other way of communicating with this dynette.cron.py
     # this is awful
     File.open("/tmp/dynette_flush_bind_cache", "w").close
+    # let's try flusing here, hope that could help ... (this design is so awful)
+    `/usr/sbin/rndc flush`
 
     # assume that the dynette.cron.py runs every minute like on prod and add a
     # bit of security margin. I hate that.


### PR DESCRIPTION
This is the PR needed to make https://github.com/YunoHost/yunohost/pull/372 works.

This was extremely painful to do.

This is actually already in prod and is working because lolilol we don't have a real dev env for dynette.

This part of the code is actually totally unreliable and is not guaranteed to work directly because we have race conditions or something like that on "dynette.cron.py" 

https://github.com/YunoHost/dynette/pull/7/commits/8446a552f2b0923479e0c42d0ab9722bcfc80b2d#diff-e77379721e481e17d2a22c488a79615dL238

But this will work "in the end" because at some point the cron will work and "yunohost dyndns update" will end up working too. Such lol design.